### PR TITLE
Fix Windows color output + add MACB tags

### DIFF
--- a/timeliner.go
+++ b/timeliner.go
@@ -107,7 +107,7 @@ func main() {
 			}
 		}
 
-		fmt.Printf("%s %s%s%s %s\n", date, hour, min, sec, tsEntry.Entry.Name)
+		fmt.Fprintf(color.Output, "%s %s%s%s %s\n", date, hour, min, sec, tsEntry.Entry.Name)
 		prev = tsEntry.Time
 	}
 }

--- a/timeliner.go
+++ b/timeliner.go
@@ -87,6 +87,13 @@ func main() {
 			os.Exit(4)
 		}
 
+		mChar := entryType(tsEntry, tsEntry.Entry.ModificationTime, "m")
+		aChar := entryType(tsEntry, tsEntry.Entry.AccessTime, "a")
+		cChar := entryType(tsEntry, tsEntry.Entry.ChangeTime, "c")
+		bChar := entryType(tsEntry, tsEntry.Entry.CreationTime, "b")
+
+		macbLine := fmt.Sprintf("%s%s%s%s", mChar, aChar, cChar, bChar)
+
 		date := tsEntry.Time.Format("2006-01-02")
 		if date == prev.Format("2006-01-02") {
 			date = colorDisabled(date)
@@ -107,7 +114,14 @@ func main() {
 			}
 		}
 
-		fmt.Fprintf(color.Output, "%s %s%s%s %s\n", date, hour, min, sec, tsEntry.Entry.Name)
+		fmt.Fprintf(color.Output, "%s %s%s%s %s %s\n", date, hour, min, sec, macbLine, tsEntry.Entry.Name)
 		prev = tsEntry.Time
 	}
+}
+
+func entryType(entry *bodyfile.TimeStampedEntry, check time.Time, c string) string {
+	if entry.Time.Equal(check) {
+		return c
+	}
+	return "."
 }


### PR DESCRIPTION
This PR fixes color output under the Windows operating system, as per the [fatih/color](https://godoc.org/github.com/fatih/color) documentation:

> Windows support is enabled by default. All Print functions work as intended. However only for color.SprintXXX functions, user should use fmt.FprintXXX and set the output to color.Output:

```go
fmt.Fprintf(color.Output, "Windows support: %s", color.GreenString("PASS"))
```

It also adds ```macb```  information to the output, by comparing the current `tsEntry.Time` to the different `macb` times. The result looks just like `mactime`'s.